### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,10 @@
-examples/* linguist-vendored=true
-.github/workflows/* linguist-vendored=true
-*.css linguist-vendored
-*.js linguist-vendored=false
+examples/** linguist-vendored
+.github/workflows/* linguist-vendored
+# JavaScript source file
+*.js linguist-documentation=false
 *.js linguist-detectable=true
-*.js linguist-language=JavaScript
+*.js linguist-language=js
+# CSS source file
+*.css linguist-documentation=false
+*.css linguist-detectable=true
+*.css linguist-language=js


### PR DESCRIPTION
## Description
I saw the question that you posted on the Stack Overflow website（https://stackoverflow.com/questions/71023000/cannot-specify-language-in-github-repository）.

## Changes
Set JavaScript as the primary language for the repository named "anypaginator".

## Screenshots
![image](https://github.com/arnemorken/anypaginator/assets/141131070/22b2e0ac-8df5-46f9-987e-d0faf7a4e361)
![image](https://github.com/arnemorken/anypaginator/assets/141131070/8cef177a-19fd-4c99-bada-098a807f38af)
